### PR TITLE
Allow dashes in acronyms

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -3,7 +3,7 @@ function filterFactory(regexp) {
 }
 
 const numbers = filterFactory(/^[0-9,.\-#]+(th|st|nd|rd)?$/);
-const acronyms = filterFactory(/^[A-Z0-9]{2,}(['\u2018-\u2019]s)?$/);
+const acronyms = filterFactory(/^[A-Z0-9\-]{2,}(['\u2018-\u2019]s)?$/);
 
 module.exports = {
   acronyms,

--- a/test/filters.spec.js
+++ b/test/filters.spec.js
@@ -8,7 +8,8 @@ describe('filters', () => {
       { word: 'AIs', index: 0 }, // controversial, not detected
       { word: 'COntains', index: 0 },
       { word: 'contaiNS', index: 0 },
-      { word: 'A1', index: 0 }
+      { word: 'A1', index: 0 },
+      { word: 'A-1', index: 0 }
     ]);
 
     expect(filteredList).toEqual([


### PR DESCRIPTION
Sometimes acronyms might be combined with numbers such as `IEC-8859-1`
and are considered a problem. This patch adds dashes to the charset that
acronyms can be made of and therefore should get rid of the matching.

One could argue that with dashes it might no longer technically be a
sole acronym but at least in a technical context I think it's quite
common to mix those and it would be quite nice to not being in the need
of adding an explicit excemption for each of them.